### PR TITLE
Add gnu tools note

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Built and tested on Debian 9. To get the demo page up:
 - Make script executable: `chmod a+rx ./tundra.sh`
 - Run the script and open output in browser: `./tundra.sh -b && xdg-open index.html`
 
+> NOTE: If you want to use this script on *BSD or macOS, please make sure you have the GNU implementation of `awk` and `sed` installed.
+
 ## Configure
 There are two types of configuration: per project and per page.
 Per project: on top of `tundra.sh` are configuration variables.

--- a/tundra.sh
+++ b/tundra.sh
@@ -21,6 +21,10 @@ MD_FLAVOUR="markdown_github+yaml_metadata_block"
 
 
 ######### Implementation ##########
+
+AWK=`which gawk || which awk`
+SED=`which gsed || which sed`
+
 usage() {
     echo "Static site generator using pandoc."
     echo "./tundra.sh"
@@ -41,14 +45,14 @@ gen_archive(){
     for url in *.html; do
         if [ "$url" != "index.html" ]
         then
-            title=`awk -vRS="</title>" '/<title>/{gsub(/.*<title>|\n+/,"");print;exit}' $url`
-            date=`awk -vRS="</p></li>" '/<li><p class="navbar-text date">/{gsub(/.*<li><p class="navbar-text date">|\n+/,"");print;exit}' $url`
+            title=`$AWK -vRS="</title>" '/<title>/{gsub(/.*<title>|\n+/,"");print;exit}' $url`
+            date=`$AWK -vRS="</p></li>" '/<li><p class="navbar-text date">/{gsub(/.*<li><p class="navbar-text date">|\n+/,"");print;exit}' $url`
             echo "<li><span class=\"date\">$date</span> - <a href=\"$url\"><span class="post-title">$title</span></a></li>" >> index.html
         fi
     done
 
     echo "</ul></body></html>" >> index.html
-    sed -i "s/blog-title/$BLOG_TITLE/g" index.html
+    $SED -i "s/blog-title/$BLOG_TITLE/g" index.html
 
     cd $ROOT
 }
@@ -102,8 +106,8 @@ then
 fi
 
 while [ "$1" != "" ]; do
-    PARAM=`echo $1 | awk -F= '{print $1}'`
-    VALUE=`echo $1 | awk -F= '{print $2}'`
+    PARAM=`echo $1 | $AWK -F= '{print $1}'`
+    VALUE=`echo $1 | $AWK -F= '{print $2}'`
     case $PARAM in
         -h | --help)
             usage


### PR DESCRIPTION
This PR adds a note to use the GNU version of `awk` and `sed` to run the script properly. It also adds a switch that tries to detect the right implementation of this tools.

> NOTE: This is only for systems different than LINUX

closes #2 