### PR TITLE
remove use of jquery

### DIFF
--- a/res/basic/blog-index.Thtml
+++ b/res/basic/blog-index.Thtml
@@ -2,10 +2,7 @@
 <head>
 <title>Blog archive</title>
 <!-- archive sort -->
-<script type="text/javascript" src="//code.jquery.com/jquery-1.7.1.js"></script>
 <script type="text/javascript">
-$(function(){
-      
 function sortUnorderedList(ul, sortDescending, sortClass) {
   if (typeof ul == "string") {
     ul = document.getElementById(ul);
@@ -51,8 +48,6 @@ window.onload = function() {
     return false;
   }
 }
-
-});
 
 </script>
 <!-- #archive sort -->


### PR DESCRIPTION
When serving the pages from file (not from an HTTP-Server) and navigating to _Blog archive_, there is an error saying: `ReferenceError: $ is not defined`

This happens because it tries to find `jquery` locally. While investigating I realized, that there is no need for `jquery` being included, since the sorting is vanillaJS already and works just fine without it (even when not served from an HTTP-Server 😉)

Works in Chrome and Firefox 🚀 