### PR TITLE
Fix blog html

### DIFF
--- a/res/basic/blog-index.Thtml
+++ b/res/basic/blog-index.Thtml
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="utf-8" />
 <title>Blog archive</title>
 <!-- archive sort -->
 <script type="text/javascript" src="//code.jquery.com/jquery-1.7.1.js"></script>

--- a/res/basic/blog-index.Thtml
+++ b/res/basic/blog-index.Thtml
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 <head>
 <title>Blog archive</title>
 <!-- archive sort -->


### PR DESCRIPTION
This PR adds an starting `<html>` tag to the blog index document as well as a `<meta>` tag that defines the `chaset` to `utf-8`.